### PR TITLE
feat(cozo-core): Add 'default_expr' column to output of '::columns'

### DIFF
--- a/cozo-core/src/runtime/db.rs
+++ b/cozo-core/src/runtime/db.rs
@@ -1777,22 +1777,28 @@ impl<'s, S: Storage<'s>> Db<S> {
         let mut rows = vec![];
         let mut idx = 0;
         for col in &handle.metadata.keys {
+            let default_expr = col.default_gen.as_ref().map(|gen| format!("{}", gen));
+
             rows.push(vec![
                 json!(col.name),
                 json!(true),
                 json!(idx),
                 json!(col.typing.to_string()),
                 json!(col.default_gen.is_some()),
+                json!(default_expr),
             ]);
             idx += 1;
         }
         for col in &handle.metadata.non_keys {
+            let default_expr = col.default_gen.as_ref().map(|gen| format!("{}", gen));
+
             rows.push(vec![
                 json!(col.name),
                 json!(false),
                 json!(idx),
                 json!(col.typing.to_string()),
                 json!(col.default_gen.is_some()),
+                json!(default_expr),
             ]);
             idx += 1;
         }
@@ -1807,6 +1813,7 @@ impl<'s, S: Storage<'s>> Db<S> {
                 "index".to_string(),
                 "type".to_string(),
                 "has_default".to_string(),
+                "default_expr".to_string(),
             ],
             rows,
         ))


### PR DESCRIPTION


<!--
ELLIPSIS_HIDDEN
-->




| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 9ba19cd4247e8ce3602028e6d986414094fa8ea6  | 
|--------|

### Summary:
This PR adds a 'default_expr' column to the output of '::columns' in the 'db.rs' file of the 'cozo-core' module, which is obtained by formatting the 'default_gen' of the column.

**Key points**:
- Added a new column 'default_expr' to the output of '::columns' in the 'db.rs' file of the 'cozo-core' module.
- The 'default_expr' is obtained by formatting the 'default_gen' of the column.
- The column name 'default_expr' is also added to the headers vector.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
